### PR TITLE
Generate sourcemap

### DIFF
--- a/dist/rollup-plugin-userscript-metablock.common.js
+++ b/dist/rollup-plugin-userscript-metablock.common.js
@@ -9,6 +9,7 @@ var YAML = _interopDefault(require('js-yaml'));
 var chalk = _interopDefault(require('chalk'));
 var validUrl = require('valid-url');
 var semver = _interopDefault(require('semver'));
+var MagicString = _interopDefault(require('magic-string'));
 
 const jclone = (o) => JSON.parse(JSON.stringify(o));
 const isString = (v) => typeof(v) === 'string';
@@ -758,7 +759,13 @@ function metablock(options = {}) {
 
   return {
     renderChunk(code) {
-      return (final + '\n\n' + code).replace(/\n+$/g, '\n');
+      const magicString = new MagicString(code);
+      magicString.prepend(final + '\n').trimEnd('\\n');
+      const result = { code: magicString.toString() };
+      if (options.sourcemap !== false) {
+        result.map = magicString.generateMap({ hires: true });
+      }
+      return result
     },
   };
 }

--- a/dist/rollup-plugin-userscript-metablock.esm.js
+++ b/dist/rollup-plugin-userscript-metablock.esm.js
@@ -5,6 +5,7 @@ import YAML from 'js-yaml';
 import chalk from 'chalk';
 import { isUri } from 'valid-url';
 import semver from 'semver';
+import MagicString from 'magic-string';
 
 const jclone = (o) => JSON.parse(JSON.stringify(o));
 const isString = (v) => typeof(v) === 'string';
@@ -754,7 +755,13 @@ function metablock(options = {}) {
 
   return {
     renderChunk(code) {
-      return (final + '\n\n' + code).replace(/\n+$/g, '\n');
+      const magicString = new MagicString(code);
+      magicString.prepend(final + '\n').trimEnd('\\n');
+      const result = { code: magicString.toString() };
+      if (options.sourcemap !== false) {
+        result.map = magicString.generateMap({ hires: true });
+      }
+      return result
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "eslint": "^6.8.0",
     "esm": "^3.2.25",
     "mocha": "^7.1.0",
-    "rollup": "^2.0.6",
-    "magic-string": "^0.25.7"
+    "rollup": "^2.0.6"
   },
   "dependencies": {
     "chalk": "^3.0.0",
     "debug": "^4.1.1",
     "js-yaml": "^3.13.1",
+    "magic-string": "^0.25.7",
     "semver": "^7.1.3",
     "valid-url": "^1.0.9"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eslint": "^6.8.0",
     "esm": "^3.2.25",
     "mocha": "^7.1.0",
-    "rollup": "^2.0.6"
+    "rollup": "^2.0.6",
+    "magic-string": "^0.25.7"
   },
   "dependencies": {
     "chalk": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ const external = [
   'semver',
   'js-yaml',
   'valid-url',
+  'magic-string'
 ];
 
 export default [{

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { loadFile, getScriptManager, getValidator, getValidOrder, sortbyOrder } 
 import { isValidMetakeyName, getMetaEntry } from './meta';
 import debug from 'debug';
 import { jclone, isObject } from './utils';
+import MagicString from 'magic-string';
 
 const parseOptions = (options) => {
   debug('plugin:parseOptions::raw options')(options);
@@ -110,7 +111,13 @@ export default function metablock(options = {}) {
 
   return {
     renderChunk(code) {
-      return (final + '\n\n' + code).replace(/\n+$/g, '\n');
+      const magicString = new MagicString(code)
+      magicString.prepend(final).trimEnd('\\n')
+      const result = { code: magicString.toString() }
+      if (options.sourcemap !== false) {
+        result.map = magicString.generateMap({ hires: true })
+      }
+      return result
     },
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ export default function metablock(options = {}) {
   return {
     renderChunk(code) {
       const magicString = new MagicString(code)
-      magicString.prepend(final).trimEnd('\\n')
+      magicString.prepend(final + '\n').trimEnd('\\n')
       const result = { code: magicString.toString() }
       if (options.sourcemap !== false) {
         result.map = magicString.generateMap({ hires: true })


### PR DESCRIPTION
Currently this plugin breaks sourcemapping in rollup.
If we use [MagicString.prepend()](https://github.com/Rich-Harris/magic-string#sprepend-content-) to prepend the metablock to the code, we can generate a sourcemap for rollup.