### PR TITLE
Respect rollup output configuration instead of a plugin option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,11 +110,11 @@ export default function metablock(options = {}) {
   debug('plugin:top::final')(final);
 
   return {
-    renderChunk(code) {
+    renderChunk(code, renderedChunk, outputOptions) {
       const magicString = new MagicString(code);
       magicString.prepend(final + '\n').trimEnd('\\n');
       const result = { code: magicString.toString() };
-      if (options.sourcemap !== false) {
+      if (outputOptions.sourcemap !== false) {
         result.map = magicString.generateMap({ hires: true });
       }
       return result;


### PR DESCRIPTION
To disable the sourcemap generation if someone doesn't need it, I had used `option.sourcemap` i.e. a new option for this plugin.

Now I realized the output file configuration from rollup configuration can be used, no need to have a plugin option
```javascript
{
  input: 'in.js',
  output: {
    file: 'out.js',
    format: 'esm',
    sourcemap: true
  }
}
```
It is in `outputOptions.sourcemap` in `renderChunk(code, renderedChunk, outputOptions)`